### PR TITLE
fix: explicitly name samples during relabel + amp_rarecurve fails for small datasets

### DIFF
--- a/workflow/rules/06-relabel.smk
+++ b/workflow/rules/06-relabel.smk
@@ -17,6 +17,7 @@ rule relabel:
         vsearch \
             --sortbysize {input} \
             --relabel {wildcards.sample}. \
+            --sample {wildcards.sample} \
             --threads {threads} \
             --output {output}
         """

--- a/workflow/scripts/Std_plots_ampvis.R
+++ b/workflow/scripts/Std_plots_ampvis.R
@@ -39,7 +39,7 @@ ggsave(snakemake@output[["Heatmap"]], heat, width = 186, units = "mm")
 # Create rarefraction curve
 rare <- amp_rarecurve(
     ampvis_obj,
-    stepsize = 150,
+    stepsize = min(max(colSums(ampvis_obj$abund)), 150),
     color_by = "SampleID"    
 ) + xlim(0,25000) + labs(title="Rarefraction curve") + ylab("Number of observed OTUs") + 
 theme(


### PR DESCRIPTION
Hi!

We use hyphens in our samples names (e.g., `sample-01-abc.fastq`), and everything after the first hyphen was trimmed away during vsearch clustering and resulted in unusable OTU tables. Using `--sample` fixes this.

`--relabel` could potentially be removed now? Or replaced with `--relabel_sha1`?

Thanks,
Bela