### PR TITLE
fix: generate OTU table even if taxonomy is not requested

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "cSpell.words": [
+        "fasta",
+        "sintax",
+        "vsearch"
+    ]
+}

--- a/workflow/rules/08-taxonomy.smk
+++ b/workflow/rules/08-taxonomy.smk
@@ -62,4 +62,26 @@ rule taxonomy_blast:
         awk '!seen[$0]++' {output.tax_raw} > {output.tax_uniq}
         }} > {log} 2>&1
         """
-        
+rule without_taxonomy:
+    input: 
+        table = os.path.join(config['output_dir'], "cluster", "{id}", "otu_cluster_{id}.tsv"),
+        fasta = os.path.join(config['output_dir'], "cluster", "{id}", "otu_{id}.fa"),
+    output:
+        table = os.path.join(config['output_dir'], "final", "{id}", "OTU_table_{id}.tsv"),
+        fasta = os.path.join(config['output_dir'], "final", "{id}", "OTUs_{id}.fna"),
+    threads:
+        1
+    resources:
+        mem_mb = 512,
+        runtime = 60
+    conda:
+        "../envs/vsearch.yml"
+    log:
+        os.path.join(config['log_dir'], "08-taxonomy", "without_taxonomy", "otu_taxonomy_{id}.log")
+    shell:
+        """
+        {{
+        cp {input.table} {output.table}
+        cp {input.fasta} {output.fasta}
+        }} > {log} 2>&1
+        """

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -113,7 +113,10 @@ def prepare_inputs():
         inputs.extend(expand(os.path.join(config['output_dir'], "final", "figs", "{id}", "Rarefaction_{id}_blast.png"), id=ids))
         inputs.extend(expand(os.path.join(config['output_dir'], "final", "figs", "{id}", "Ordination_{id}_blast.png"), id=ids))
         inputs.extend(expand(os.path.join(config['output_dir'], "final", "figs", "{id}", "Boxplot_{id}_blast.png"), id=ids))
-        inputs.extend(expand(os.path.join(config['output_dir'], "final", "R-environment", "{id}", "R-environment_{id}_blast.RData"), id=ids))        
-    inputs.append(expand(os.path.join(config['output_dir'], "final", "report", "total_reads.tsv")))
-    inputs.append(expand(os.path.join(config["output_dir"], "config.txt")))
+        inputs.extend(expand(os.path.join(config['output_dir'], "final", "R-environment", "{id}", "R-environment_{id}_blast.RData"), id=ids))
+    if not any((config["include_sintax_output"], config["include_blast_output"])):
+        inputs.extend(expand(os.path.join(config['output_dir'], "final", "{id}", "OTU_table_{id}.tsv"), id=ids))
+        inputs.extend(expand(os.path.join(config['output_dir'], "final", "{id}", "OTUs_{id}.fna"), id=ids))
+    inputs.append(os.path.join(config['output_dir'], "final", "report", "total_reads.tsv"))
+    inputs.append(os.path.join(config["output_dir"], "config.txt"))
     return inputs


### PR DESCRIPTION
Hi,

in case the config is set to:

```
include_blast_output: False
include_sintax_output: False
```

there was no output generated. We run our own classifiers, so we only need the OTU table and the OTU fasta file, which is now supported with this PR.

Thanks,
Bela