### PR TITLE
ASVs must be made from all reads + filter singletons

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ NOTE: BLAST results in a high degree of “edge-cases” due to the formatting o
 * `ONT-AmpSeq-main/results/final/{id}/phyloseq_abundance_{id}_{tax}.tsv`: This matrix contains number of reads per sample per OTU. This OTU table is preformatted to be directly compatible with the otu_table for creating and analysing a [phyloseq object](https://joey711.github.io/phyloseq/).
 * `ONT-AmpSeq-main/results/final/report/total_reads.tsv`: This file provides an overview of the number of reads in each sample pre- and post-filtering.
 * `ONT-AmpSeq-main/results/final/figs/{id}/Heatmap_{id}_{tax}.png`: Heatmap, showing the relative abundance of top 25 most abundant genera.
-* `ONT-AmpSeq-main/results/final/figs/{id}/Rarefraction_{id}_{tax}.png`: Rarefraction curve, showing number of reads versus number of observed OTUs.
+* `ONT-AmpSeq-main/results/final/figs/{id}/Rarefaction_{id}_{tax}.png`: Rarefaction curve, showing number of reads versus number of observed OTUs.
 * `ONT-AmpSeq-main/results/final/figs/{id}/Ordination_{id}_{tax}.png`: Ordination plot, using simple PCA.
 * `ONT-AmpSeq-main/results/config.txt`: Text file, capturing the configurations used in the analysis.
 ## Stats script (nanoplot.sh)

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -58,3 +58,11 @@ primer_r: 22
 # Default values are provided
 f: 0.0002
 K: "500M"
+
+# unoise denoising, minimum read count for each ASV
+# (should always be 2 or more)
+unoise_minsize: 8
+
+# OTU clustering, minimum read count for each OTU cluster centroid
+# (should always be 2 or more)
+clustering_minsize: 8

--- a/workflow/rules/01-concatenate_fastq.smk
+++ b/workflow/rules/01-concatenate_fastq.smk
@@ -1,6 +1,3 @@
-include: "common.smk"
-
-
 rule concatenate_fastq:
     input:
         lambda wildcards: listFastq(wildcards),

--- a/workflow/rules/03-clustering.smk
+++ b/workflow/rules/03-clustering.smk
@@ -13,8 +13,6 @@ rule convert_to_fasta:
     resources:
         mem_mb=512,
         runtime=60,
-    conda:
-        "../envs/vsearch.yml"
     log:
         os.path.join(
             config["log_dir"], "03-clustering", "convert_to_fasta", "{sample}.log"

--- a/workflow/rules/03-clustering.smk
+++ b/workflow/rules/03-clustering.smk
@@ -1,8 +1,6 @@
 configfile: "config/config.yaml"
 
-
 import os
-
 
 rule convert_to_fasta:
     input:
@@ -12,7 +10,7 @@ rule convert_to_fasta:
     threads: 1
     resources:
         mem_mb=512,
-        runtime=60,
+        runtime=30,
     log:
         os.path.join(
             config["log_dir"], "03-clustering", "convert_to_fasta", "{sample}.log"
@@ -21,38 +19,110 @@ rule convert_to_fasta:
         """
         {{
             echo "Starting conversion to FASTA for sample {wildcards.sample}"
+            # will this work with interleaved fastq files?
             sed -n '1~4s/^@/>/p;2~4p' {input} > {output}
             echo "Finished conversion to FASTA for sample {wildcards.sample}"
         }} > {log} 2>&1  
     """
 
-
-rule vsearch_cluster:
+rule concatenate_all_samples:
     input:
-        os.path.join(config["tmp_dir"], "samples", "{sample}_filtered.fasta"),
+        expand(
+            os.path.join(
+                config["tmp_dir"], "samples", "{sample}_filtered.fasta"
+            ),
+            sample=get_samples(),
+        ),
+    # Use aggregate rule to concatenate all files using wildcard.sample
     output:
         os.path.join(
-            config["output_dir"], "vsearch", "samples", "{sample}_cluster.fasta"
+            config["tmp_dir"], "samples", "all_samples.fasta"
+        ),
+    conda:
+        "../envs/mapping.yml"
+    log:
+        os.path.join(
+            config["log_dir"], "03-clustering", "concatenate_all_samples.log"
+        ),
+    resources:
+        mem_mb=512,
+        runtime=30,
+    shell:
+        """
+        {{
+        echo "Starting concatenation of OTUs"
+        cat {input} > {output}
+        echo "Finished concatenation of OTUs"
+        }} > {log} 2>&1
+        """
+
+rule concatenated_derep:
+    input:
+        os.path.join(
+            config["tmp_dir"], "samples", "all_samples.fasta"
+        ),
+    output:
+        os.path.join(
+            config["output_dir"], "vsearch", "samples", "concatenated_derep.fasta"
+        ),
+    threads: 1
+    resources:
+        mem_mb=8192,
+        runtime=60,
+    conda:
+        "../envs/vsearch.yml"
+    log:
+        os.path.join(
+            config["log_dir"], "03-clustering", "concatenated_derep.log"
+        ),
+    shell:
+        """
+        {{
+            echo "Starting dereplication of concatenated sequences from all samples"
+            vsearch --derep_fulllength \
+                {input} \
+                --sizeout \
+                --fasta_width 0 \
+                --output {output} \
+                --minuniquesize 2
+            echo "Finished dereplication of concatenated sequences from all samples"
+        }} > {log} 2>&1
+    """
+    
+
+rule vsearch_denoise:
+    input:
+        os.path.join(
+            config["output_dir"], "vsearch", "samples", "concatenated_derep.fasta"
+        ),
+    output:
+        os.path.join(
+            config["output_dir"], "vsearch", "denoised.fasta"
         ),
     threads: config["max_threads"]
     resources:
         mem_mb=8192,
         runtime=1440,
+    params:
+        unoise_minsize = config['unoise_minsize'],
     conda:
         "../envs/vsearch.yml"
     log:
         os.path.join(
-            config["log_dir"], "03-clustering", "vsearch_cluster", "{sample}.log"
+            config["log_dir"], "03-clustering", "vsearch_denoise.log"
         ),
     shell:
         """
         {{
-            echo "Starting clustering for sample {wildcards.sample}"
+            echo "Starting denoising all reads "
+            # unoise is for Illumina reads only
             vsearch \
                 --cluster_unoise {input} \
-                --minsize 1 \
+                --minsize {params.unoise_minsize} \
                 --threads {threads} \
-                --centroids {output}
-            echo "Finished clustering for sample {wildcards.sample}"
+                --centroids {output} \
+                --sizein \
+                --sizeout
+            echo "Finished denoising all reads"
         }} > {log} 2>&1
     """

--- a/workflow/rules/04-mapping.smk
+++ b/workflow/rules/04-mapping.smk
@@ -1,49 +1,16 @@
 import glob
 import os
 
-
-rule concatenate_otus:
-    input:
-        expand(
-            os.path.join(
-                config["output_dir"], "vsearch", "samples", "{sample}_cluster.fasta"
-            ),
-            sample=get_samples(),
-        ),
-    # Use aggregate rule to concatenate all files using wildcard.sample
-    output:
-        os.path.join(
-            config["output_dir"], "vsearch", "samples", "concatenated_otus.fasta"
-        ),
-    conda:
-        "../envs/mapping.yml"
-    log:
-        os.path.join(
-            config["log_dir"], "04-mapping", "concatenate_otus", "concatenate_otus.log"
-        ),
-    resources:
-        mem_mb=1024,
-        runtime=60,
-    shell:
-        """
-        {{
-        echo "Starting concatenation of OTUs"
-        cat {input} > {output}
-        echo "Finished concatenation of OTUs"
-        }} > {log} 2>&1
-        """
-
-
 rule mapping:
     input:
         combined=os.path.join(
-            config["output_dir"], "vsearch", "samples", "concatenated_otus.fasta"
+            config["output_dir"], "vsearch", "denoised.fasta"
         ),
         samples=os.path.join(
-            config["output_dir"], "vsearch", "samples", "{sample}_cluster.fasta"
+            config["tmp_dir"], "samples", "{sample}_filtered.fasta"
         ),
     output:
-        os.path.join(config["output_dir"], "mapping", "samples", "{sample}_aligned.sam"),
+        touch(os.path.join(config["output_dir"], "mapping", "samples", "{sample}_aligned.sam")),
     resources:
         mem_mb = 40960,
         runtime = 2880

--- a/workflow/rules/05-polish_racon.smk
+++ b/workflow/rules/05-polish_racon.smk
@@ -1,18 +1,18 @@
 rule polish_racon:
     input:
         combined=os.path.join(
-            config["output_dir"], "vsearch", "samples", "concatenated_otus.fasta"
+            config["output_dir"], "vsearch", "denoised.fasta"
         ),
         alignment=os.path.join(
             config["output_dir"], "mapping", "samples", "{sample}_aligned.sam"
         ),
         polish_target=os.path.join(
-            config["output_dir"], "vsearch", "samples", "{sample}_cluster.fasta"
+            config["tmp_dir"], "samples", "{sample}_filtered.fasta"
         ),
     output:
-        os.path.join(
+        touch(os.path.join(
             config["output_dir"], "polish", "samples", "{sample}_polished.fasta"
-        ),
+        )),
     conda:
         "../envs/polish.yml"
     threads: config["max_threads"]
@@ -24,6 +24,7 @@ rule polish_racon:
     shell:
         """
         {{
+        # make a check here to check if file is empty or not
         racon \
         {input.combined} \
         {input.alignment} \

--- a/workflow/rules/11-prep_for_phyloseq.smk
+++ b/workflow/rules/11-prep_for_phyloseq.smk
@@ -1,6 +1,3 @@
-include: "common.smk"
-
-
 rule phyloseq_abund_sintax:
     input:
         os.path.join(config["output_dir"], "cluster", "{id}", "otu_cluster_{id}.tsv"),

--- a/workflow/rules/13-ampvis2_std_plots.smk
+++ b/workflow/rules/13-ampvis2_std_plots.smk
@@ -10,7 +10,7 @@ rule ampvis2_std_plots_sintax:
         Heatmap=os.path.join(
             config["output_dir"], "final", "figs", "{id}", "Heatmap_{id}_sintax.png"
         ),
-        Rarefraction=os.path.join(
+        Rarefaction=os.path.join(
             config["output_dir"],
             "final",
             "figs",
@@ -59,7 +59,7 @@ rule ampvis2_std_plots_blast:
         Heatmap=os.path.join(
             config["output_dir"], "final", "figs", "{id}", "Heatmap_{id}_blast.png"
         ),
-        Rarefraction=os.path.join(
+        Rarefaction=os.path.join(
             config["output_dir"], "final", "figs", "{id}", "Rarefaction_{id}_blast.png"
         ),
         Ordination=os.path.join(

--- a/workflow/rules/13-ampvis2_std_plots.smk
+++ b/workflow/rules/13-ampvis2_std_plots.smk
@@ -1,6 +1,3 @@
-include: "common.smk"
-
-
 rule ampvis2_std_plots_sintax:
     input:
         OTU_sintax=os.path.join(

--- a/workflow/scripts/Std_plots_ampvis.R
+++ b/workflow/scripts/Std_plots_ampvis.R
@@ -36,16 +36,16 @@ heat <- amp_heatmap(ampvis_obj,
 
 ggsave(snakemake@output[["Heatmap"]], heat, width = 186, units = "mm")
 
-# Create rarefraction curve
+# Create rarefaction curve
 rare <- amp_rarecurve(
     ampvis_obj,
     stepsize = min(max(colSums(ampvis_obj$abund)), 150),
     color_by = "SampleID"    
-) + xlim(0,25000) + labs(title="Rarefraction curve") + ylab("Number of observed OTUs") + 
+) + xlim(0,25000) + labs(title="Rarefaction curve") + ylab("Number of observed OTUs") + 
 theme(
     axis.text.x = element_text(angle = 90, hjust = 1), panel.border = element_rect(fill=NA, color="Black", size = 0.5, linetype = "solid"),  panel.grid.major = element_blank(), panel.grid.minor  = element_blank(), axis.line = element_line(colour = "black")
     )
-ggsave(snakemake@output[["Rarefraction"]], rare, width = 186, units = "mm")
+ggsave(snakemake@output[["Rarefaction"]], rare, width = 186, units = "mm")
 
 # Create ordination plot
 ord <- amp_ordinate(


### PR DESCRIPTION
Massive speed ups and better quality data. Following [usearch standard procedures](https://drive5.com/usearch/manual/uparse_pipeline.html), all reads must be pooled when making OTU/zOTUs/ASVs (https://drive5.com/usearch/manual/pipe_readprep.html), and normal amount is probably max 50k. I used to get 30 million with the current version of the workflow, which is probably 10x the amount of known bacteria in the world :) Takes ages to map. But the cause is that singletons must always be filtered when making OTU/zOTUs, since the purpose after all is: "Denoising attempts to identify all correct biological sequences in the reads." (https://drive5.com/usearch/manual/pipe_otus.html). Singletons likely won't get classified anyways because they contain errors. Even with high quality MiSeq data, the minimum read count for a zOTU should be 8 before even being considered one, and ONT data is lower quality, so should potentially be even higher to be sure most are true-positives. But I made it configurable now. Briefly tested the workflow, but may need additional changes. In case of empty files because of filtering, you can use [touch()](https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#flag-files) and some conditionals in shell commands. Take a look, happy to discuss.